### PR TITLE
Spot-v1 for target following

### DIFF
--- a/models/boston_dynamics_spot/scene_v1.xml
+++ b/models/boston_dynamics_spot/scene_v1.xml
@@ -1,0 +1,24 @@
+<mujoco model="spot scene">
+  <include file="spot.xml"/>
+
+  <statistic center="0.15 0.1 0.38" extent=".8" meansize="0.05"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="220" elevation="-10"/>
+    <quality shadowsize="8192"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+  </asset>
+
+  <worldbody>
+    <site name="target_site" pos="0 0 0.1" size="0.1" rgba="1 0 0 0.7"/>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+  </worldbody>
+</mujoco>

--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -1,6 +1,6 @@
 from envs.ant import CustomAntEnv
 from envs.viperx import ViperXEnv
-from envs.spot import SpotEnv
+from envs.spot import *
 from envs.cassie import CassieEnv
 
 from gymnasium.envs.registration import register
@@ -21,7 +21,14 @@ register(
 
 register(
     id="Spot-v0",
-    entry_point="envs:SpotEnv",
+    entry_point="envs:SpotEnvV0",
+    max_episode_steps=1000,
+    reward_threshold=6000.0,
+)
+
+register(
+    id="Spot-v1",
+    entry_point="envs:SpotEnvV1",
     max_episode_steps=1000,
     reward_threshold=6000.0,
 )

--- a/src/envs/spot/__init__.py
+++ b/src/envs/spot/__init__.py
@@ -1,0 +1,2 @@
+from envs.spot.v0_forward import SpotEnvV0
+from envs.spot.v1_target import SpotEnvV1

--- a/src/envs/spot/v0_forward.py
+++ b/src/envs/spot/v0_forward.py
@@ -1,0 +1,257 @@
+from typing import Dict, Tuple, Union
+from gymnasium.spaces import Box
+from gymnasium.envs.mujoco import MujocoEnv
+import mujoco
+import numpy as np
+
+DEFAULT_CAMERA_CONFIG = {
+    "distance": 4.0,
+}
+
+
+class SpotEnvV0(MujocoEnv):
+    """
+    Uses the Spot Quadruped developed by Boston Dynamics.
+
+    The goal of this environment is to achieve stable forward locomotion.
+    """
+
+    metadata = {
+        "render_modes": [
+            "human",
+            "rgb_array",
+            "depth_array",
+        ],
+    }
+
+    def __init__(
+        self,
+        xml_file: str = "boston_dynamics_spot/scene.xml",
+        frame_skip: int = 5,  # each 'step' of the environment corresponds to 5 timesteps in the simulation
+        default_camera_config: Dict[str, Union[float, int]] = DEFAULT_CAMERA_CONFIG,
+        healthy_reward: float = 1.0,  # reward for staying alive
+        forward_reward_weight: float = 1.0,  # reward for forward locomotion
+        main_body: Union[int, str] = 1,
+        terminate_when_unhealthy: bool = True,  # terminate the episode when the robot is unhealthy
+        termination_cost: float = 1000.0,  # penalty for terminating the episode early
+        healthy_z_range: Tuple[float, float] = (
+            0.25,
+            1.0,
+        ),  # z range for the robot to be healthy
+        ctrl_cost_weight: float = 0.1,  # penalize large/jerky actions
+        contact_cost_weight: float = 0.0005,  # penalize contacts with the ground
+        reset_noise_scale: float = 0.005,  # noise scale for resetting the robot's position
+        contact_force_range: Tuple[float, float] = (-1.0, 1.0),
+        exclude_current_positions_from_observation: bool = True,
+        include_cfrc_ext_in_observation: bool = False,
+        **kwargs,
+    ):
+        # initialize the environment variables
+        self._healthy_reward = healthy_reward
+        self._forward_reward_weight = forward_reward_weight
+        self._ctrl_cost_weight = ctrl_cost_weight
+        self._contact_cost_weight = contact_cost_weight
+
+        # healthy - robot must fit in a certain height range(e.g. not falling down)
+        self._healthy_z_range = healthy_z_range
+        self._terminate_when_unhealthy = terminate_when_unhealthy
+        self._termination_cost = termination_cost
+
+        self._main_body = main_body
+
+        self._reset_noise_scale = reset_noise_scale
+
+        # clip range for rewards related to contact forces
+        self._contact_force_range = contact_force_range
+
+        self._exclude_current_positions_from_observation = (
+            exclude_current_positions_from_observation
+        )
+        self._include_cfrc_ext_in_observation = include_cfrc_ext_in_observation
+
+        self.metadata = SpotEnv.metadata
+
+        MujocoEnv.__init__(
+            self,
+            xml_file,
+            frame_skip,
+            observation_space=None,  # needs to be defined after
+            default_camera_config=default_camera_config,
+            **kwargs,
+        )
+
+        # required for MujocoEnv
+        self.metadata = {
+            "render_modes": [
+                "human",
+                "rgb_array",
+                "depth_array",
+            ],
+            "render_fps": int(np.round(1.0 / self.dt)),
+        }
+
+        # for observations, we collect the model's qpos and qvel
+        obs_size = self.data.qpos.size + self.data.qvel.size
+
+        # we also add a relative angle between the forward vector of the torso and the x-axis
+        obs_size += 1
+
+        # we may exclude the x and y coordinates of the torso(root link) for position agnostic behavior in policies.
+        obs_size -= 2 * exclude_current_positions_from_observation
+
+        # we may include the external forces acting on the robot
+        obs_size += len(self.cfrc_ext) * include_cfrc_ext_in_observation
+
+        # metadata for the final observation space
+        self.observation_structure = {
+            "qpos": self.data.qpos.size,
+            "qvel": self.data.qvel.size,
+            "direction_angle": 1,
+            "cfrc_ext": len(self.cfrc_ext) * include_cfrc_ext_in_observation,
+        }
+
+        self.observation_space = Box(
+            low=-np.inf, high=np.inf, shape=(obs_size,), dtype=np.float64
+        )
+
+    @property
+    def cfrc_ext(self):
+        return self.data.cfrc_ext[1:]
+
+    @property
+    def healthy_reward(self):
+        return self.is_healthy * self._healthy_reward
+
+    @property
+    def termination_cost(self):
+        return (
+            self._terminate_when_unhealthy and (not self.is_healthy)
+        ) * self._termination_cost
+
+    def control_cost(self, action):
+        control_cost = self._ctrl_cost_weight * np.sum(np.square(action))
+        return control_cost
+
+    @property
+    def contact_forces(self):
+        raw_contact_forces = self.cfrc_ext
+        min_value, max_value = self._contact_force_range
+        contact_forces = np.clip(raw_contact_forces, min_value, max_value)
+        return contact_forces
+
+    @property
+    def contact_cost(self):
+        contact_cost = self._contact_cost_weight * np.sum(
+            np.square(self.contact_forces)
+        )
+        return contact_cost
+
+    @property
+    def is_healthy(self):
+        state = self.state_vector()
+        min_z, max_z = self._healthy_z_range
+        is_healthy = np.isfinite(state).all() and min_z <= state[2] <= max_z
+        return is_healthy
+
+    # the z component is ignored as the desired direction is in the x-y plane
+    def forward_angle(self):
+        target_vector = np.array([-1, 0])
+
+        rot_matrix_body = self.data.xmat[self._main_body]
+        rot_matrix_body = rot_matrix_body.reshape(3, 3)
+
+        body_forward_vector = rot_matrix_body @ np.array([-1, 0, 0])
+        body_forward_vector = body_forward_vector[:2]
+
+        diff_angle = np.arccos(
+            np.clip(
+                np.dot(target_vector, body_forward_vector),
+                -1.0,
+                1.0,
+            )
+        )
+
+        return diff_angle
+
+    def _get_obs(self):
+        # get the current state of the robot
+        qpos = self.data.qpos.copy()
+        qvel = self.data.qvel.copy()
+
+        angle = np.array([self.forward_angle()])
+
+        # exclude the x and y coordinates of the torso(root link) for position agnostic behavior in policies.
+        if self._exclude_current_positions_from_observation:
+            qpos = qpos[2:]
+
+        obs = np.concatenate([qpos, qvel, angle])
+
+        # include the external forces acting on the robot
+        if self._include_cfrc_ext_in_observation:
+            obs = np.concatenate([obs, self.cfrc_ext])
+
+        return obs
+
+    def _get_rew(self, x_velocity: float, action):
+        forward_reward = x_velocity * self._forward_reward_weight
+        healthy_reward = self.healthy_reward
+        rewards = forward_reward + healthy_reward
+
+        ctrl_cost = self.control_cost(action)
+        contact_cost = self.contact_cost
+        termination_cost = self.termination_cost
+        costs = ctrl_cost + contact_cost + termination_cost
+
+        reward = rewards - costs
+
+        reward_info = {
+            "reward_forward": forward_reward,
+            "reward_ctrl": -ctrl_cost,
+            "reward_contact": -contact_cost,
+            "reward_termination": -termination_cost,
+            "reward_survive": healthy_reward,
+        }
+
+        return reward, reward_info
+
+    def step(self, action):
+        xy_position_before = self.data.body(self._main_body).xpos[:2].copy()
+        self.do_simulation(action, self.frame_skip)
+        xy_position_after = self.data.body(self._main_body).xpos[:2].copy()
+
+        x_velocity, y_velocity = (xy_position_after - xy_position_before) / self.dt
+
+        observation = self._get_obs()
+        reward, reward_info = self._get_rew(x_velocity, action)
+        terminated = (not self.is_healthy) and self._terminate_when_unhealthy
+        info = {
+            "x_position": self.data.qpos[0],
+            "y_position": self.data.qpos[1],
+            "distance_from_origin": np.linalg.norm(self.data.qpos[0:2], ord=2),
+            "x_velocity": x_velocity,
+            "y_velocity": y_velocity,
+            **reward_info,
+        }
+
+        if self.render_mode == "human":
+            self.render()
+
+        return observation, reward, terminated, False, info
+
+    def reset_model(self):
+        noise_low = -self._reset_noise_scale
+        noise_high = self._reset_noise_scale
+
+        qpos = self.init_qpos + self.np_random.uniform(
+            low=noise_low, high=noise_high, size=self.model.nq
+        )
+        qvel = (
+            self.init_qvel
+            + self._reset_noise_scale * self.np_random.standard_normal(self.model.nv)
+        )
+
+        self.set_state(qpos, qvel)
+
+        observation = self._get_obs()
+
+        return observation

--- a/src/envs/spot/v1_target.py
+++ b/src/envs/spot/v1_target.py
@@ -1,0 +1,339 @@
+from typing import Dict, Tuple, Union
+from gymnasium.spaces import Box
+from gymnasium.envs.mujoco import MujocoEnv
+import mujoco
+import numpy as np
+
+DEFAULT_CAMERA_CONFIG = {
+    "distance": 4.0,
+}
+
+
+class SpotEnvV1(MujocoEnv):
+    """
+    Uses the Spot Quadruped developed by Boston Dynamics.
+
+    The goal of this environment is to achieve stable locomotion towards a given target position.
+    """
+
+    metadata = {
+        "render_modes": [
+            "human",
+            "rgb_array",
+            "depth_array",
+        ],
+    }
+
+    def __init__(
+        self,
+        xml_file: str = "boston_dynamics_spot/scene_v1.xml",
+        frame_skip: int = 5,  # each 'step' of the environment corresponds to 5 timesteps in the simulation
+        default_camera_config: Dict[str, Union[float, int]] = DEFAULT_CAMERA_CONFIG,
+        healthy_reward: float = 1.0,  # reward for staying alive
+        forward_reward_weight: float = 1.0,  # reward for getting closer to the target
+        success_reward_weight: float = 10000.0,  # reward for reaching the target
+        main_body: Union[int, str] = 1,
+        terminate_when_unhealthy: bool = True,  # terminate the episode when the robot is unhealthy
+        termination_cost: float = 10000.0,  # penalty for terminating the episode early
+        healthy_z_range: Tuple[float, float] = (
+            0.25,
+            1.0,
+        ),  # z range for the robot to be healthy
+        ctrl_cost_weight: float = 0.1,  # penalize large/jerky actions
+        contact_cost_weight: float = 0.0005,  # penalize contacts with the ground
+        reset_noise_scale: float = 0.005,  # noise scale for resetting the robot's position
+        contact_force_range: Tuple[float, float] = (-1.0, 1.0),
+        exclude_current_positions_from_observation: bool = True,
+        include_cfrc_ext_in_observation: bool = False,
+        max_target_range=5.0,  # absolute coordinate(x, y) range for the target position
+        randomize_target_position: bool = True,
+        initial_target_range: float = 1.0,
+        target_range_increment: float = 0.1,
+        increment_frequency: int = 1000,  # Environment steps per increment (# of calls to `step()`)
+        **kwargs,
+    ):
+        # initialize the environment variables
+        self._healthy_reward = healthy_reward
+        self._forward_reward_weight = forward_reward_weight
+        self._ctrl_cost_weight = ctrl_cost_weight
+        self._contact_cost_weight = contact_cost_weight
+        self._success_reward_weight = success_reward_weight
+
+        # healthy - robot must fit in a certain height range(e.g. not falling down)
+        self._healthy_z_range = healthy_z_range
+        self._terminate_when_unhealthy = terminate_when_unhealthy
+        self._termination_cost = termination_cost
+
+        self._max_target_range = max_target_range
+        self._target_range = initial_target_range
+        self._target_range_increment = target_range_increment
+        self._increment_frequency = increment_frequency
+        self._steps = 0
+        
+        self._randomize_target_position = randomize_target_position
+        self.target_pos = self._generate_target_position()
+
+        self.target_site_id = None  # site ID for the target position
+
+        self._main_body = main_body
+
+        self._reset_noise_scale = reset_noise_scale
+
+        # clip range for rewards related to contact forces
+        self._contact_force_range = contact_force_range
+
+        self._exclude_current_positions_from_observation = (
+            exclude_current_positions_from_observation
+        )
+        self._include_cfrc_ext_in_observation = include_cfrc_ext_in_observation
+
+        self.metadata = SpotEnvV1.metadata
+
+        MujocoEnv.__init__(
+            self,
+            xml_file,
+            frame_skip,
+            observation_space=None,  # needs to be defined after
+            default_camera_config=default_camera_config,
+            **kwargs,
+        )
+
+        # required for MujocoEnv
+        self.metadata = {
+            "render_modes": [
+                "human",
+                "rgb_array",
+                "depth_array",
+            ],
+            "render_fps": int(np.round(1.0 / self.dt)),
+        }
+
+        # for observations, we collect the model's qpos and qvel
+        obs_size = self.data.qpos.size + self.data.qvel.size
+
+        # we also add a relative target position vector (x,y)
+        obs_size += 2
+
+        # we may exclude the x and y coordinates of the torso(root link) for position agnostic behavior in policies.
+        obs_size -= 2 * exclude_current_positions_from_observation
+
+        # we may include the external forces acting on the robot
+        obs_size += len(self.cfrc_ext) * include_cfrc_ext_in_observation
+
+        # metadata for the final observation space
+        self.observation_structure = {
+            "qpos": self.data.qpos.size,
+            "qvel": self.data.qvel.size,
+            "relative_target_pos": 2,
+            "cfrc_ext": len(self.cfrc_ext) * include_cfrc_ext_in_observation,
+        }
+
+        self.observation_space = Box(
+            low=-np.inf, high=np.inf, shape=(obs_size,), dtype=np.float64
+        )
+
+    @property
+    def cfrc_ext(self):
+        return self.data.cfrc_ext[1:]
+
+    @property
+    def healthy_reward(self):
+        return self.is_healthy * self._healthy_reward
+
+    @property
+    def termination_cost(self):
+        return (
+            self._terminate_when_unhealthy and (not self.is_healthy)
+        ) * self._termination_cost
+
+    def control_cost(self, action):
+        control_cost = self._ctrl_cost_weight * np.sum(np.square(action))
+        return control_cost
+
+    @property
+    def contact_forces(self):
+        raw_contact_forces = self.cfrc_ext
+        min_value, max_value = self._contact_force_range
+        contact_forces = np.clip(raw_contact_forces, min_value, max_value)
+        return contact_forces
+
+    @property
+    def contact_cost(self):
+        contact_cost = self._contact_cost_weight * np.sum(
+            np.square(self.contact_forces)
+        )
+        return contact_cost
+
+    @property
+    def is_healthy(self):
+        state = self.state_vector()
+        min_z, max_z = self._healthy_z_range
+        is_healthy = np.isfinite(state).all() and min_z <= state[2] <= max_z
+        return is_healthy
+
+    @property
+    def goal_reached(self) -> bool:
+        distance_to_target = np.linalg.norm(
+            self.target_pos - self.data.body(self._main_body).xpos[:2], ord=2
+        )
+        return distance_to_target < 0.5
+
+    @property
+    def success_reward(self):
+        return self.goal_reached * self._success_reward_weight
+
+    # z coordinate is omitted as the robot is expected to move in the x-y plane
+    def _generate_target_position(self):
+        x = self.np_random.uniform(low=-self._target_range, high=self._target_range)
+        y = self.np_random.uniform(low=-self._target_range, high=self._target_range)
+        return np.array([x, y], dtype=np.float32)
+
+    def _get_obs(self):
+        # get the current state of the robot
+        qpos = self.data.qpos.copy()
+        qvel = self.data.qvel.copy()
+
+        relative_target_pos = self.target_pos - self.data.body(self._main_body).xpos[:2]
+
+        # exclude the x and y coordinates of the torso(root link) for position agnostic behavior in policies.
+        if self._exclude_current_positions_from_observation:
+            qpos = qpos[2:]
+
+        obs = np.concatenate([qpos, qvel, relative_target_pos])
+
+        # include the external forces acting on the robot
+        if self._include_cfrc_ext_in_observation:
+            obs = np.concatenate([obs, self.cfrc_ext])
+
+        return obs
+
+    def get_body_global_velocity(self, body_id):
+        """Gets the full linear velocity of a body in the global frame."""
+        vel = np.zeros(6, dtype=np.float64)
+        mujoco.mj_objectVelocity(
+            self.model, self.data, mujoco.mjtObj.mjOBJ_BODY, body_id, vel, 0
+        )
+        return vel[3:]  # Return only linear velocity (global frame)
+
+    def get_local_forward_velocity(self, body_id):
+        """
+        Calculates the forward velocity in the robot's local frame.
+        The dot projection is necessary due to potential rotations to the local frame of the body
+        """
+
+        # 1. Get Global Velocity
+        global_velocity = self.get_body_global_velocity(body_id)
+
+        # 2. Get Local Forward Vector (from rotation matrix)
+        rot_matrix = self.data.body(body_id).xmat.reshape(3, 3)
+        local_forward_vector = -rot_matrix[
+            :, 0
+        ]  # First column is forward (x-axis in local frame)
+
+        # 3. Project Global Velocity onto Local Forward Vector
+        forward_velocity = np.dot(global_velocity, local_forward_vector)
+
+        return forward_velocity
+
+    def _get_rew(self, action):
+        distance_to_target = np.linalg.norm(
+            self.target_pos - self.data.body(self._main_body).xpos[:2], ord=2
+        )
+
+        x_velocity = self.get_local_forward_velocity(self._main_body)
+        forward_reward = (
+            self._forward_reward_weight * x_velocity * np.exp(-distance_to_target)
+        )
+
+        healthy_reward = self.healthy_reward
+        success_reward = self.success_reward
+        rewards = forward_reward + healthy_reward + success_reward
+
+        ctrl_cost = self.control_cost(action)
+        contact_cost = self.contact_cost
+        termination_cost = self.termination_cost
+        costs = ctrl_cost + contact_cost + termination_cost
+
+        reward = rewards - costs
+
+        reward_info = {
+            "reward_forward": forward_reward,
+            "reward_success": success_reward,
+            "reward_ctrl": -ctrl_cost,
+            "reward_contact": -contact_cost,
+            "reward_termination": -termination_cost,
+            "reward_survive": healthy_reward,
+        }
+
+        return reward, reward_info
+
+    def step(self, action):
+        self.do_simulation(action, self.frame_skip)
+        
+        self._steps += 1
+        if self._steps % self._increment_frequency == 0:
+            self._target_range = min (
+                self._target_range + self._target_range_increment,
+                self._max_target_range
+            )
+
+        observation = self._get_obs()
+        reward, reward_info = self._get_rew(action)
+
+        # termination condition 1. unhealthy
+        terminated = (not self.is_healthy) and self._terminate_when_unhealthy
+        # termination condition 2. goal reached
+        terminated = terminated or self.goal_reached
+
+        info = {
+            "x_position": self.data.qpos[0],
+            "y_position": self.data.qpos[1],
+            "distance_from_origin": np.linalg.norm(self.data.qpos[0:2], ord=2),
+            **reward_info,
+        }
+
+        if self.render_mode == "human":
+            self.render()
+
+        return observation, reward, terminated, False, info
+
+    def render(self, *args, **kwargs):
+        self._render_target()
+        super().render(*args, **kwargs)
+
+    def _render_target(self):
+        if self.target_site_id is None:
+            # Find the site ID (or create one in your XML if it doesn't exist)
+            self.target_site_id = mujoco.mj_name2id(
+                self.model, mujoco.mjtObj.mjOBJ_SITE, "target_site"
+            )
+            if self.target_site_id == -1:
+                raise ValueError(
+                    "Site 'target_site' not found in the XML model. Please add it."
+                )
+
+        # Update the site's position
+        self.model.site_pos[self.target_site_id] = np.concatenate(
+            [self.target_pos, [0.1]]
+        )  # Adjust Z as needed
+
+    def reset_model(self):
+        noise_low = -self._reset_noise_scale
+        noise_high = self._reset_noise_scale
+
+        qpos = self.init_qpos + self.np_random.uniform(
+            low=noise_low, high=noise_high, size=self.model.nq
+        )
+        qvel = (
+            self.init_qvel
+            + self._reset_noise_scale * self.np_random.standard_normal(self.model.nv)
+        )
+
+        if self._randomize_target_position:
+            self.target_pos = self._generate_target_position()
+
+        self.set_state(qpos, qvel)
+
+        observation = self._get_obs()
+
+        return observation

--- a/src/ppo.py
+++ b/src/ppo.py
@@ -626,12 +626,10 @@ class PPO:
         self.logger["entropy_losses"] = []
         self.logger["approx_kl"] = []
 
-
     def save_model(self):
         torch.save(self.actor.state_dict(), "./ppo_actor.pth")
         torch.save(self.critic.state_dict(), "./ppo_critic.pth")
 
-    
     def load_model(self):
         self.actor.load_state_dict(torch.load("./ppo_actor.pth", weights_only=True))
         self.critic.load_state_dict(torch.load("./ppo_critic.pth", weights_only=True))
@@ -657,11 +655,11 @@ models_path = os.path.join(parent_path, "models")
 # )
 
 env = gym.make(
-    "Cassie-v0",
-    render_mode="human",
+    "Spot-v1",
+    # render_mode="human",
     frame_skip=5,
-    max_episode_steps=1000,  # physics steps will have been multiplied by 5, due to the frame_skip value
-    xml_file=os.path.join(models_path, "agility_cassie/scene.xml"),
+    max_episode_steps=2000,  # physics steps will have been multiplied by 5, due to the frame_skip value
+    xml_file=os.path.join(models_path, "boston_dynamics_spot/scene_v1.xml"),
 )
 
 myppo = PPO(


### PR DESCRIPTION
- Moved `Spot-v0` under `spot` directory
- Added `Spot-v1` for target following instead of pure forward locomotion
- Experimenting with curriculum learning (incrementally difficult environments)